### PR TITLE
Add a --filter_local option

### DIFF
--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -20,8 +20,11 @@ module Puppet::CatalogDiff
      if active_nodes.empty?
        raise "No active nodes were returned from your fact search"
      end
-     found_nodes = yaml_cache.select { |node| active_nodes.include?(node) }
-     found_nodes
+     if options[:filter_local]
+       yaml_cache.select { |node| active_nodes.include?(node) }
+     else
+       active_nodes
+     end
     end
 
     def find_nodes_local(fact,value)

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -29,6 +29,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary 'Do not print classes in resource diffs'
     end
 
+    option "--filter_local" do
+      summary "Use local YAML node files to filter out queried nodes"
+    end
+
     option "--changed_depth=" do
       summary "The number of nodes to display sorted by changes"
       default_to { "10" }

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -28,6 +28,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary "Use puppetdb to do the fact search instead of the rest api"
     end
 
+    option "--filter_local" do
+      summary "Use local YAML node files to filter out queried nodes"
+    end
+
     option "--changed_depth=" do
       summary "The number of problem files to display sorted by changes"
 


### PR DESCRIPTION
Because you might not want to filter out nodes (when using PuppetDB as a node source for example).