### PR TITLE
Fix typo

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -31,6 +31,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
 
     option "--filter_local" do
       summary "Use local YAML node files to filter out queried nodes"
+    end
 
     option "--use_puppetdb" do
       summary "Use puppetdb to do the fact search instead of the rest api"


### PR DESCRIPTION
This was introduced when use_puppetdb was exposed.  Without this it currently bombs out with a syntax error.