### PR TITLE
Add dating information

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -24,8 +24,11 @@ module Puppet::CatalogDiff
 
     def diff(options = {})
       from = []
+      from_meta = {}
       to   = []
-      { from_file => from, to_file => to}.each do |r,v|
+      to_meta = {}
+      { from_file => [ from, from_meta ], to_file => [ to, to_meta ]}.each do |r,a|
+        v, m = a
         unless File.exist?(r)
           raise "Cannot find resources in #{r}"
         end
@@ -42,6 +45,8 @@ module Puppet::CatalogDiff
 	else
 	  raise "Provide catalog with the approprtiate file extension, valid extensions are pson, yaml and marshal"
         end
+
+        m[:version] = tmp.version
 
         if @version == "0.24"
           convert24(tmp, v)
@@ -63,6 +68,8 @@ module Puppet::CatalogDiff
       titles[:from] = extract_titles(from)
 
       output = {}
+      output[:old_version] = from_meta[:version]
+      output[:new_version] = to_meta[:version]
       output[:total_resources_in_old] = titles[:from].size
       output[:total_resources_in_new] = titles[:to].size
 

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -154,6 +154,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
       nodes[:most_changed]       = most_changed.reverse.take((options.has_key?(:changed_depth) && options[:changed_depth].to_i || 10))
       nodes[:most_differences]   = most_differences.reverse.take((options.has_key?(:changed_depth) && options[:changed_depth].to_i || 10))
       nodes[:total_nodes]        = total_nodes
+      nodes[:date]               = Time.new.to_s
       nodes
     end
 
@@ -162,7 +163,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
 
       format = Puppet::CatalogDiff::Formater.new()
       nodes.collect do |node,summary|
-      next if node == :total_percentage or node == :total_nodes or node == :most_changed or node == :with_changes or node == :most_differences or node == :pull_output
+      next if node == :total_percentage or node == :total_nodes or node == :most_changed or node == :with_changes or node == :most_differences or node == :pull_output or node == :date
       format.node_summary_header(node,summary,:node_percentage) + summary.collect do |header,value|
         next if value.nil?
         if value.is_a?(Hash)


### PR DESCRIPTION
This PR adds two information to the report:

* The generation date (global info)
* Two node fields: `old_version` and `new_version`, using the catalog versions.