### PR TITLE
The diff action doesn't clean after itself

### DIFF
--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -128,6 +128,8 @@ Puppet::Face.define(:catalog, '0.0.1') do
         pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb])
         diff_output = Puppet::Face[:catalog, '0.0.1'].diff(old_catalogs,new_catalogs,options)
         nodes = diff_output
+        FileUtils.rm_rf(old_catalogs)
+        FileUtils.rm_rf(new_catalogs)
         nodes[:pull_output] = pull_output
         # Save the file as it can take a while to create
         if options[:output_report]


### PR DESCRIPTION
It leaves a lot of temp files in /tmp after the run.