### PR TITLE
Filter classes in searchfacts

### DIFF
--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -75,7 +75,7 @@ module Puppet::CatalogDiff
         base_query.concat([["=", "catalog-environment", env]]) if env
         real_facts = @facts.select { |k, v| !v.nil? }
         query = base_query.concat(real_facts.map { |k, v| ["=", ["fact", k], v] })
-        classes = @facts.select { |k, v| v.nil? }.keys
+        classes = Hash[@facts.select { |k, v| v.nil? }].keys
         classes.each do |c|
           capit = c.split('::').map{ |n| n.capitalize }.join('::')
           query = query.concat(


### PR DESCRIPTION
This PR allows to filter classes passed in the `fact_search` parameter:

```
--fact_search "kernel=Linux,apache"
```

making it a composite filter