### PR TITLE
Canonicalize Puppet 4 catalogs

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -40,6 +40,12 @@ module Puppet::CatalogDiff
           tmp = Marshal.load(File.read(r))
         when '.pson'
           tmp = PSON.load(File.read(r))
+          unless tmp.respond_to? :version
+            tmp = PSON.load({
+              'document_type' => 'Catalog',
+              'data' => PSON.load(File.read(r)),
+            }.to_pson)
+          end
         when '.json'
           tmp = PSON.load(File.read(r))
 	else


### PR DESCRIPTION
Puppet 4 catalogs are not parsed properly by `PSON.load`. This fixes it.

Arguably, this is probably kind of a hack, we might want to fix this another way…