### PR TITLE
Add downgrade catalog option

### DIFF
--- a/lib/puppet/catalog-diff/differ.rb
+++ b/lib/puppet/catalog-diff/differ.rb
@@ -48,8 +48,8 @@ module Puppet::CatalogDiff
           end
         when '.json'
           tmp = PSON.load(File.read(r))
-	else
-	  raise "Provide catalog with the approprtiate file extension, valid extensions are pson, yaml and marshal"
+        else
+          raise "Provide catalog with the approprtiate file extension, valid extensions are pson, yaml and marshal"
         end
 
         m[:version] = tmp.version
@@ -59,6 +59,11 @@ module Puppet::CatalogDiff
         else
           convert25(tmp, v)
         end
+      end
+
+      if options[:downgrade_catalog]
+        from = normalize_to_current_parser(from)
+        to = normalize_to_current_parser(to)
       end
 
       if options[:exclude_classes]

--- a/lib/puppet/catalog-diff/preprocessor.rb
+++ b/lib/puppet/catalog-diff/preprocessor.rb
@@ -111,5 +111,36 @@ module Puppet::CatalogDiff
         collector << resource
       end
     end
+
+    def convert_integer_to_str(node)
+      if node.kind_of? Integer
+        return node.to_s
+      elsif node.kind_of? Array
+        new = []
+        node.each do |i|
+          new << convert_integer_to_str(i)
+        end
+        return new
+      elsif node.kind_of? Hash
+        new = {}
+        node.each_pair do |k,v|
+          new[k] = convert_integer_to_str(v)
+        end
+        return new
+      end
+      return node
+    end
+
+    def normalize_to_current_parser(catalog)
+      catalog.each do |resource|
+        resource[:parameters].each_pair do |param, value|
+          if value.kind_of?(Array) and value.size == 1
+            value = value.first
+          end
+
+          resource[:parameters][param] = convert_integer_to_str(value)
+        end
+      end
+    end
   end
 end

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -37,6 +37,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       summary 'Do not print classes in resource diffs'
     end
 
+    option "--downgrade_catalog" do
+      summary 'Normalize parser to old style 3.x "current" parser type'
+    end
+
     option "--filter_local" do
       summary "Use local YAML node files to filter out queried nodes"
     end


### PR DESCRIPTION
Puppet 3.x current and future parser produce catalogs that are different
in ways that aren't actually important to the content of the catalog.
The primary differences are the current parser treats all integers as
strings, and never creates a single element array.

Ideally to compare a current and future parser catalog we would upgrade
the current parser catalog, but there just isn't enough information to
be able to do that.

This patch adds a new --downgrade_catalog command-line option that will
preprocess all catalogs given before diffing them to remove spurious
changes in the catalog caused by future parser differences.
