### PR TITLE
Don't search nodes with REST when filter_local param is provided

### DIFF
--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -16,14 +16,13 @@ module Puppet::CatalogDiff
      if options[:use_puppetdb]
        Puppet.debug("Using puppetDB to find active nodes")
        active_nodes = find_nodes_puppetdb(old_env)
-     else
-       Puppet.debug("Using Fact Reset Interface to find active nodes")
-       active_nodes = find_nodes_rest(old_server)
-     end
-     if options[:filter_local]
+     elsif options[:filter_local]
        Puppet.debug("Using YAML cache to find active nodes")
        yaml_cache = find_nodes_local()
        active_nodes = yaml_cache
+     else
+       Puppet.debug("Using Fact Reset Interface to find active nodes")
+       active_nodes = find_nodes_rest(old_server)
      end
      if active_nodes.empty?
        raise "No active nodes were returned from your fact search"


### PR DESCRIPTION
If one provides the `--filter_local` param it first looked up
with REST and then in local yaml files overriding the earlier results.
Looks like the conditon was accidentially added below and not as elsif.

This changes the condition to only lookup in local cache when
filter_local is provided and default to REST lookup.
