### PR TITLE
Add option to list hosts from all puppetdb environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ directly rather than via the rest terminus. However the rest terminus should
 be the same list of nodes if they are both backed by puppetdb and so this
 option is only for environments where puppetdb is more authoritative in some
 way they the facts rest query. This option is provided for future compatibility.
+By default, `--use-puppetdb` only lists hosts present in the source environment
+at last report time. The `--all-environments` option will list all hosts.
 
 You can run this face without root access if you run the script as the puppet user
 on the system. The following is an example script doing so. You can alternatively

--- a/lib/puppet/catalog-diff/searchfacts.rb
+++ b/lib/puppet/catalog-diff/searchfacts.rb
@@ -15,7 +15,11 @@ module Puppet::CatalogDiff
      old_env = options[:old_server].split('/')[1]
      if options[:use_puppetdb]
        Puppet.debug("Using puppetDB to find active nodes")
-       active_nodes = find_nodes_puppetdb(old_env)
+       if options[:all_environments]
+         active_nodes = find_nodes_puppetdb(nil)
+       else
+         active_nodes = find_nodes_puppetdb(old_env)
+       end
      else
        Puppet.debug("Using Fact Reset Interface to find active nodes")
        active_nodes = find_nodes_rest(old_server)

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -55,6 +55,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { "10" }
     end
 
+    option "--all-environments" do
+      summary "List machines from all environments rather than just the source environment"
+    end
+
     description <<-'EOT'
       Prints the differences between catalogs compiled by different puppet master to help
       during migrating to a new Puppet version.
@@ -143,7 +147,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         # User passed use two hostnames
         old_catalogs = Dir.mktmpdir("#{catalog1.gsub('/', '_')}-")
         new_catalogs = Dir.mktmpdir("#{catalog2.gsub('/', '_')}-")
-        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_local => options[:filter_local])
+        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_local => options[:filter_local], :all_environments => options[:all_environments])
         diff_output = Puppet::Face[:catalog, '0.0.1'].diff(old_catalogs,new_catalogs,options)
         nodes = diff_output
         FileUtils.rm_rf(old_catalogs)

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -38,6 +38,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { '10' }
     end
 
+    option "--all-environments" do
+      summary "List machines from all environments rather than just the source environment"
+    end
+
     description <<-'EOT'
       This action is used to seed a series of catalogs from two servers
     EOT


### PR DESCRIPTION
Adds an `--all-environments` option to the `diff` and `pull` faces so that when retrieving hosts from puppetdb, hosts from all environments may be considered.