### PR TITLE
Use v4 catalog

### DIFF
--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -11,6 +11,9 @@ module Puppet::CatalogDiff
         if p.has_key?('issue_kind')
           raise p['message']
         end
+        if certless
+          catalog = render_pson(p['catalog'])
+        end
         save_catalog_to_disk(save_directory,node_name,catalog,'pson')
       rescue Exception => e
         Puppet.err("Server returned invalid catalog for #{node_name}")

--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -39,7 +39,7 @@ module Puppet::CatalogDiff
     def compile_catalog(node_name,server)
       server,environment = server.split('/')
       environment ||= lookup_environment(node_name)
-      endpoint = "/#{environment}/catalog/#{node_name}"
+      endpoint = "/puppet/v3/catalog/#{node_name}?environment=#{environment}"
       server,port = server.split(':')
       port ||= '8140'
       Puppet.debug("Connecting to server: #{server}")

--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -7,11 +7,11 @@ module Puppet::CatalogDiff
       @node_name = node_name
       catalog = compile_catalog(node_name,server)
       begin
-        PSON.parse(catalog)
-        save_catalog_to_disk(save_directory,node_name,catalog,'pson')
-        if catalog.has_key?('issue_kind')
-          raise c.message
+        p = PSON.parse(catalog)
+        if p.has_key?('issue_kind')
+          raise p['message']
         end
+        save_catalog_to_disk(save_directory,node_name,catalog,'pson')
       rescue Exception => e
         Puppet.err("Server returned invalid catalog for #{node_name}")
         save_catalog_to_disk(save_directory,node_name,catalog,'error')

--- a/lib/puppet/catalog-diff/compilecatalog.rb
+++ b/lib/puppet/catalog-diff/compilecatalog.rb
@@ -9,6 +9,9 @@ module Puppet::CatalogDiff
       begin
         PSON.parse(catalog)
         save_catalog_to_disk(save_directory,node_name,catalog,'pson')
+        if catalog.has_key?('issue_kind')
+          raise c.message
+        end
       rescue Exception => e
         Puppet.err("Server returned invalid catalog for #{node_name}")
         save_catalog_to_disk(save_directory,node_name,catalog,'error')

--- a/lib/puppet/face/catalog/diff.rb
+++ b/lib/puppet/face/catalog/diff.rb
@@ -55,6 +55,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { "10" }
     end
 
+    option "--certless" do
+      summary "Use the certless catalog API (Puppet >= 6.3.0)"
+    end
+
     description <<-'EOT'
       Prints the differences between catalogs compiled by different puppet master to help
       during migrating to a new Puppet version.
@@ -143,7 +147,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         # User passed use two hostnames
         old_catalogs = Dir.mktmpdir("#{catalog1.gsub('/', '_')}-")
         new_catalogs = Dir.mktmpdir("#{catalog2.gsub('/', '_')}-")
-        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_local => options[:filter_local])
+        pull_output = Puppet::Face[:catalog, '0.0.1'].pull(old_catalogs,new_catalogs,options[:fact_search],:old_server => catalog1,:new_server => catalog2,:changed_depth => options[:changed_depth], :threads => options[:threads], :use_puppetdb => options[:use_puppetdb], :filter_local => options[:filter_local], :certless => options[:certless])
         diff_output = Puppet::Face[:catalog, '0.0.1'].diff(old_catalogs,new_catalogs,options)
         nodes = diff_output
         FileUtils.rm_rf(old_catalogs)

--- a/lib/puppet/face/catalog/pull.rb
+++ b/lib/puppet/face/catalog/pull.rb
@@ -38,6 +38,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { '10' }
     end
 
+    option "--certless" do
+      summary "Use the certless catalog API (Puppet >= 6.3.0)"
+    end
+
     description <<-'EOT'
       This action is used to seed a series of catalogs from two servers
     EOT
@@ -71,11 +75,11 @@ Puppet::Face.define(:catalog, '0.0.1') do
          while node_name = mutex.synchronize { nodes.pop }
             begin
               if nodes.size.odd?
-                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server] )
-                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server] )
+                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless] )
+                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless] )
               else
-                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server] )
-                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server] )
+                new_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog2,node_name,:master_server => options[:new_server],:certless => options[:certless] )
+                old_server = Puppet::Face[:catalog, '0.0.1'].seed(catalog1,node_name,:master_server => options[:old_server],:certless => options[:certless] )
               end
               mutex.synchronize { compiled_nodes + old_server[:compiled_nodes] }
               mutex.synchronize { compiled_nodes + new_server[:compiled_nodes] }

--- a/lib/puppet/face/catalog/seed.rb
+++ b/lib/puppet/face/catalog/seed.rb
@@ -12,6 +12,10 @@ Puppet::Face.define(:catalog, '0.0.1') do
       default_to { Facter.value('fqdn') }
     end
 
+    option "--certless" do
+      summary "Use the certless catalog API (Puppet >= 6.3.0)"
+    end
+
     description <<-'EOT'
       This action is used to seed a series of catalogs to then be compared with diff
     EOT
@@ -53,7 +57,7 @@ Puppet::Face.define(:catalog, '0.0.1') do
         Thread.new(nodes,compiled_nodes,options) do |nodes,compiled_nodes,options|
           while node_name = mutex.synchronize { nodes.pop }
             begin
-              compiled = Puppet::CatalogDiff::CompileCatalog.new(node_name,save_directory,options[:master_server])
+              compiled = Puppet::CatalogDiff::CompileCatalog.new(node_name,save_directory,options[:master_server],options[:certless])
               mutex.synchronize { compiled_nodes << node_name }
             rescue Exception => e
               Puppet.err("Unable to compile catalog for #{node_name}\n\t#{e}")


### PR DESCRIPTION
Puppet 6's `/puppet/v4/catalog` endpoint allows to compile catalogs without sending trusted facts.

This PR adds a `--certless` to use this API instead of the standard `v3` API